### PR TITLE
[18.0][IMP] account_payment_base_oca*: remove excludes in manifest

### DIFF
--- a/account_payment_base_oca/__manifest__.py
+++ b/account_payment_base_oca/__manifest__.py
@@ -13,7 +13,6 @@
     "development_status": "Mature",
     "website": "https://github.com/OCA/bank-payment-alternative",
     "depends": ["account_payment_method_base"],
-    "excludes": ["account_payment_mode"],
     "data": [
         "views/account_payment_method.xml",
         "views/account_payment_method_line.xml",

--- a/account_payment_base_oca_sale/__manifest__.py
+++ b/account_payment_base_oca_sale/__manifest__.py
@@ -11,7 +11,6 @@
     "author": "Akretion, Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/bank-payment-alternative",
     "depends": ["sale", "account_payment_base_oca"],
-    "excludes": ["account_payment_sale"],
     "data": [
         "views/sale_order.xml",
         "views/sale_report.xml",


### PR DESCRIPTION
Remove excludes in manifest that are not absolutely necessary, in order to improve cohabitation between OCA/bank-payment and OCA/bank-payment-alternative