### PR TITLE
[18.0][IMP] Code clean-up/improvements + allow internal bank transfers

### DIFF
--- a/account_payment_base_oca_sale/tests/common.py
+++ b/account_payment_base_oca_sale/tests/common.py
@@ -54,13 +54,28 @@ class CommonTestCase(TransactionCase):
             }
         )
         cls.products = {
-            "prod_order": cls.env.ref("product.product_order_01"),
-            "prod_del": cls.env.ref("product.product_delivery_01"),
+            "prod_order": cls.env["product.product"].create(
+                {
+                    "name": "Test consu invoice on order",
+                    "type": "consu",
+                    "invoice_policy": "order",
+                    "list_price": 12.42,
+                }
+            ),
+            "prod_del": cls.env["product.product"].create(
+                {
+                    "name": "Test consu invoice on delivery",
+                    "type": "consu",
+                    "invoice_policy": "delivery",
+                    "list_price": 13.13,
+                }
+            ),
             "serv_order": cls.env["product.product"].create(
                 {
                     "name": "Test service product order",
                     "type": "service",
                     "invoice_policy": "order",
+                    "list_price": 42.12,
                 }
             ),
             "serv_del": cls.env["product.product"].create(
@@ -68,6 +83,7 @@ class CommonTestCase(TransactionCase):
                     "name": "Test service product delivery",
                     "type": "service",
                     "invoice_policy": "delivery",
+                    "list_price": 12.34,
                 }
             ),
         }

--- a/account_payment_batch_oca/models/account_payment.py
+++ b/account_payment_batch_oca/models/account_payment.py
@@ -9,9 +9,13 @@ from odoo.tools.misc import format_amount, format_date
 class AccountPayment(models.Model):
     _inherit = "account.payment"
 
-    payment_order_id = fields.Many2one(comodel_name="account.payment.order")
-    payment_lot_id = fields.Many2one(comodel_name="account.payment.lot")
-    payment_line_ids = fields.Many2many(comodel_name="account.payment.line")
+    payment_order_id = fields.Many2one(
+        comodel_name="account.payment.order", readonly=True
+    )
+    payment_lot_id = fields.Many2one(comodel_name="account.payment.lot", readonly=True)
+    payment_line_ids = fields.Many2many(
+        comodel_name="account.payment.line", readonly=True
+    )
     order_state = fields.Selection(
         related="payment_order_id.state", string="Payment Order State"
     )
@@ -37,6 +41,16 @@ class AccountPayment(models.Model):
                     for line in pay.available_payment_method_line_ids
                     if line.code not in to_exclude
                 ]
+        return res
+
+    # Don't generate a journal entry when the account.payment is an "internal transfer"
+    # of the company i.e. a money transfer between 2 bank accounts of the company
+    @api.depends("partner_id", "company_id")
+    def _compute_outstanding_account_id(self):
+        res = super()._compute_outstanding_account_id()
+        for pay in self:
+            if pay.company_id.partner_id == self.partner_id or not self.partner_id:
+                pay.outstanding_account_id = False
         return res
 
     def _prepare_payment_order_mail(self, lang, account_number_scrambled_ctx):

--- a/account_payment_batch_oca/models/account_payment_line.py
+++ b/account_payment_batch_oca/models/account_payment_line.py
@@ -41,6 +41,8 @@ class AccountPaymentLine(models.Model):
         string="Journal Item",
         ondelete="restrict",
         check_company=True,
+        domain="[('reconciled','=', False), ('account_id.reconcile', '=', True), "
+        "('partner_id', '!=', False)]",
     )
     ml_maturity_date = fields.Date(related="move_line_id.date_maturity")
     currency_id = fields.Many2one(
@@ -78,7 +80,7 @@ class AccountPaymentLine(models.Model):
     )
     partner_bank_id = fields.Many2one(
         comodel_name="res.partner.bank",
-        compute="_compute_payment_line",
+        compute="_compute_partner_bank_id",
         store=True,
         readonly=False,
         precompute=True,
@@ -244,7 +246,7 @@ class AccountPaymentLine(models.Model):
             key.append(str(self[field]))
         return tuple(key)
 
-    @api.depends("partner_id", "move_line_id")
+    @api.depends("move_line_id")
     def _compute_payment_line(self):
         for line in self:
             communication = False
@@ -252,9 +254,9 @@ class AccountPaymentLine(models.Model):
             currency_id = line.company_id.currency_id.id
             amount_currency = 0.0
             move_line = line.move_line_id
-            partner = line.partner_id
-            partner_bank_id = False
-            if move_line:
+            partner_id = False
+            if move_line and move_line.partner_id:
+                partner_id = move_line.partner_id.id
                 communication_type = move_line.move_id.reference_type
                 communication = (
                     move_line.move_id._get_payment_order_communication_full()
@@ -263,21 +265,41 @@ class AccountPaymentLine(models.Model):
                 amount_currency = move_line.amount_residual_currency
                 if line.order_id.payment_type == "outbound":
                     amount_currency *= -1
-                    partner_bank_id = move_line.move_id.partner_bank_id.id
-                partner = move_line.partner_id
-            if (
-                partner
-                and line.order_id.payment_method_id.bank_account_required
-                and not partner_bank_id
-                and partner.bank_ids
-            ):
-                partner_bank_id = partner.bank_ids[0].id
             line.communication = communication
             line.communication_type = communication_type
             line.currency_id = currency_id
             line.amount_currency = amount_currency
-            line.partner_id = partner and partner.id or False
-            line.partner_bank_id = partner_bank_id
+            line.partner_id = partner_id
+
+    @api.depends(
+        "partner_id",
+        "move_line_id",
+        "order_id.journal_id",
+        "order_id.company_id",
+        "order_id.payment_method_id",
+    )
+    def _compute_partner_bank_id(self):
+        for line in self:
+            partner_bank = False
+            partner = line.partner_id
+            order = line.order_id
+            move = line.move_line_id.move_id
+            if order.payment_method_id.bank_account_required:
+                if (
+                    move
+                    and move.move_type in ("in_invoice", "in_refund")
+                    and order.payment_type == "outbound"
+                ):
+                    partner_bank = move.partner_bank_id
+                elif partner:
+                    if partner == order.company_id.partner_id:  # internal transfer
+                        for bank_account in partner.bank_ids:
+                            if bank_account != order.journal_id.bank_account_id:
+                                partner_bank = bank_account
+                                break
+                    elif partner.bank_ids:
+                        partner_bank = partner.bank_ids[0]
+            line.partner_bank_id = partner_bank
 
     def _draft2open_payment_line_check(self):
         self.ensure_one()

--- a/account_payment_batch_oca/models/account_payment_line.py
+++ b/account_payment_batch_oca/models/account_payment_line.py
@@ -3,6 +3,7 @@
 
 from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools.misc import format_date
 
 
 class AccountPaymentLine(models.Model):
@@ -278,19 +279,21 @@ class AccountPaymentLine(models.Model):
             line.partner_id = partner and partner.id or False
             line.partner_bank_id = partner_bank_id
 
-    def draft2open_payment_line_check(self):
+    def _draft2open_payment_line_check(self):
         self.ensure_one()
+        order = self.order_id
+        errors = []
         if self.bank_account_required:
             if not self.partner_bank_id:
-                raise UserError(
+                errors.append(
                     _("Missing Partner Bank Account on payment line %s") % self.name
                 )
             if (
-                self.order_id.payment_type == "outbound"
-                and self.order_id._enforce_allow_out_payment()
+                order.payment_type == "outbound"
+                and order._enforce_allow_out_payment()
                 and not self.partner_bank_id.allow_out_payment
             ):
-                raise UserError(
+                errors.append(
                     _(
                         "Bank account '%(bank_account)s' of partner '%(partner)s' "
                         "is untrusted. Check that this bank account can be trusted "
@@ -300,16 +303,36 @@ class AccountPaymentLine(models.Model):
                     )
                 )
         if not self.communication:
-            raise UserError(_("Communication is empty on payment line %s.") % self.name)
+            errors.append(_("Communication is empty on payment line %s.") % self.name)
         if (
-            self.order_id.payment_method_line_id.mail_notif
+            order.payment_method_line_id.mail_notif
             and self.mail_notif_partner_id
             and not self.mail_notif_partner_id.email
         ):
-            raise UserError(
+            errors.append(
                 _("Missing email on notification partner '%s'.")
                 % self.mail_notif_partner_id.display_name
             )
+        # inbound: check option no_debit_before_maturity
+        if (
+            order.payment_type == "inbound"
+            and order.payment_method_line_id.no_debit_before_maturity
+            and self.ml_maturity_date
+            and self.date < self.ml_maturity_date
+        ):
+            errors.append(
+                _(
+                    "The payment method '%(method)s' has the option "
+                    "'Disallow Debit Before Maturity Date'. The "
+                    "payment line %(pline)s has a maturity date %(mdate)s "
+                    "which is after the computed payment date %(pdate)s.",
+                    method=order.payment_method_line_id.display_name,
+                    pline=self.name,
+                    mdate=format_date(self.env, self.ml_maturity_date),
+                    pdate=format_date(self.env, self.date),
+                )
+            )
+        return errors
 
     def _prepare_account_payment_vals(self, payment_lot, pay_sequence):
         """Prepare the dictionary to create an account payment record from a set of

--- a/account_payment_batch_oca/models/account_payment_line.py
+++ b/account_payment_batch_oca/models/account_payment_line.py
@@ -271,7 +271,7 @@ class AccountPaymentLine(models.Model):
                 and not partner_bank_id
                 and partner.bank_ids
             ):
-                partner_bank_id = partner.bank_ids[0]
+                partner_bank_id = partner.bank_ids[0].id
             line.communication = communication
             line.communication_type = communication_type
             line.currency_id = currency_id
@@ -288,20 +288,45 @@ class AccountPaymentLine(models.Model):
                 errors.append(
                     _("Missing Partner Bank Account on payment line %s") % self.name
                 )
-            if (
-                order.payment_type == "outbound"
-                and order._enforce_allow_out_payment()
-                and not self.partner_bank_id.allow_out_payment
-            ):
-                errors.append(
-                    _(
-                        "Bank account '%(bank_account)s' of partner '%(partner)s' "
-                        "is untrusted. Check that this bank account can be trusted "
-                        "and activate the option 'Send Money' on it.",
-                        bank_account=self.partner_bank_id.display_name,
-                        partner=self.partner_id.display_name,
+            else:
+                if self.partner_bank_id.partner_id != self.partner_id:
+                    errors.append(
+                        _(
+                            "On payment line %(name)s with partner '%(partner)s', "
+                            "the bank account '%(bank_account)s' belongs to partner "
+                            "'%(bank_account_partner)s'.",
+                            name=self.name,
+                            partner=self.partner_id.display_name,
+                            bank_account=self.partner_bank_id.display_name,
+                            bank_account_partner=self.partner_bank_id.partner_id.display_name,
+                        )
                     )
-                )
+
+                if (
+                    order.payment_type == "outbound"
+                    and order._enforce_allow_out_payment()
+                    and not self.partner_bank_id.allow_out_payment
+                ):
+                    errors.append(
+                        _(
+                            "Bank account '%(bank_account)s' of partner '%(partner)s' "
+                            "is untrusted. Check that this bank account can be trusted "
+                            "and activate the option 'Send Money' on it.",
+                            bank_account=self.partner_bank_id.display_name,
+                            partner=self.partner_id.display_name,
+                        )
+                    )
+                # internal transfers: check source account != dest account
+                if self.partner_bank_id == order.company_partner_bank_id:
+                    errors.append(
+                        _(
+                            "On payment line %(name)s, the bank account "
+                            "'%(bank_account)s' is the same as the company "
+                            "bank account of the payment order.",
+                            name=self.name,
+                            bank_account=self.partner_bank_id.display_name,
+                        )
+                    )
         if not self.communication:
             errors.append(_("Communication is empty on payment line %s.") % self.name)
         if (

--- a/account_payment_batch_oca/models/account_payment_order.py
+++ b/account_payment_batch_oca/models/account_payment_order.py
@@ -333,6 +333,10 @@ class AccountPaymentOrder(models.Model):
                 order.journal_id = False
 
     def cancel2draft(self):
+        # Delete existing payments
+        self.payment_ids.unlink()
+        # Delete existing lots
+        self.payment_lot_ids.unlink()
         self.write({"state": "draft"})
 
     def action_cancel(self):
@@ -356,9 +360,8 @@ class AccountPaymentOrder(models.Model):
     def draft2open(self):
         """
         Called when you click on the 'Confirm' button
-        Set the 'date' on payment line depending on the 'date_prefered'
-        setting of the payment.order
-        Re-generate the account payments.
+        Set the 'date' on payment line depending on the 'date_prefered' of the order
+        Generate the account payments and lots
         """
         today = fields.Date.context_today(self)
         for order in self:
@@ -378,22 +381,22 @@ class AccountPaymentOrder(models.Model):
                 raise UserError(
                     _("There are no transactions on payment order %s.") % order.name
                 )
-            # Unreconcile, cancel and delete existing account payments
-            order.payment_ids.action_draft()
-            order.payment_ids.action_cancel()
-            order.payment_ids.unlink()
-            # Delete existing lots
-            order.payment_lot_ids.unlink()
+            if order.payment_ids:
+                raise UserError(
+                    _("%s is linked to existing payments. This should never happen.")
+                    % order.name
+                )
+            if order.payment_lot_ids:
+                raise UserError(
+                    _("%s is linked to existing lots. This should never happen.")
+                    % order.name
+                )
             # Prepare account payments from the payment lines
             payline_err_text = set()
             group_paylines = {}  # key = pay_key
             pay_key2lot = {}  # key = pay_key, value = payment_lot
             lot_key2lot = {}  # key = lot_key, value = payment_lot
             for payline in order.payment_line_ids:
-                try:
-                    payline.draft2open_payment_line_check()
-                except UserError as e:
-                    payline_err_text.add(e.args[0])
                 # Compute requested payment date
                 if order.date_prefered == "due":
                     requested_date = payline.ml_maturity_date or payline.date or today
@@ -403,26 +406,9 @@ class AccountPaymentOrder(models.Model):
                     requested_date = today
                 # No payment date in the past
                 requested_date = max(today, requested_date)
-                # inbound: check option no_debit_before_maturity
-                if (
-                    order.payment_type == "inbound"
-                    and order.payment_method_line_id.no_debit_before_maturity
-                    and payline.ml_maturity_date
-                    and requested_date < payline.ml_maturity_date
-                ):
-                    payline_err_text.add(
-                        _(
-                            "The payment method '%(method)s' has the option "
-                            "'Disallow Debit Before Maturity Date'. The "
-                            "payment line %(pline)s has a maturity date %(mdate)s "
-                            "which is after the computed payment date %(pdate)s.",
-                            method=order.payment_method_line_id.display_name,
-                            pline=payline.name,
-                            mdate=format_date(self.env, payline.ml_maturity_date),
-                            pdate=format_date(self.env, requested_date),
-                        )
-                    )
-                payline.date = requested_date
+                payline.write({"date": requested_date})
+                for error in payline._draft2open_payment_line_check():
+                    payline_err_text.add(error)
                 # Group options
                 pay_key = (
                     payline._payment_line_grouping_key()
@@ -447,10 +433,6 @@ class AccountPaymentOrder(models.Model):
             # Raise errors that happened on the validation process
             if payline_err_text:
                 raise UserError("\n".join(payline_err_text))
-
-            # Why do we have to call flush_all() ??? A comment to explain would
-            # be welcomed!
-            order.env.flush_all()
 
             # Create account payments
             lot2pay_seq = defaultdict(int)

--- a/account_payment_batch_oca/views/account_payment.xml
+++ b/account_payment_batch_oca/views/account_payment.xml
@@ -20,8 +20,29 @@
         <field name="arch" type="xml">
             <group name="group2" position="inside">
                 <field name="payment_reference" invisible="not payment_reference" />
+                <field name="payment_order_id" invisible="not payment_order_id" />
                 <field name="payment_lot_id" invisible="not payment_lot_id" />
             </group>
+            <!-- Field partner_bank_id is displayed 3 times the view!
+            We want to set the field string="Vendor Bank Account" as readonly -->
+            <xpath
+                expr="//group[@name='group2']/field[@name='partner_bank_id'][1]"
+                position="attributes"
+            >
+                <attribute name="readonly">payment_order_id</attribute>
+            </xpath>
+            <xpath
+                expr="//group[@name='group2']/field[@name='partner_bank_id'][2]"
+                position="attributes"
+            >
+                <attribute name="readonly">payment_order_id</attribute>
+            </xpath>
+            <field name="memo" position="attributes">
+                <attribute name="readonly">payment_order_id</attribute>
+            </field>
+            <field name="payment_reference" position="attributes">
+                <attribute name="readonly">payment_order_id</attribute>
+            </field>
         </field>
     </record>
 </odoo>

--- a/account_payment_batch_oca/views/account_payment_line.xml
+++ b/account_payment_batch_oca/views/account_payment_line.xml
@@ -24,8 +24,9 @@
                         <field
                             name="partner_bank_id"
                             context="{'default_partner_id': partner_id}"
-                            domain="[('partner_id', '=', partner_id)]"
+                            domain="[('partner_id', '=', partner_id), ('id', '!=', parent.company_partner_bank_id)]"
                             required="bank_account_required"
+                            invisible="not partner_id"
                         />
                         <field name="bank_account_required" invisible="1" />
                         <field name="date" />

--- a/account_payment_batch_oca/views/account_payment_line.xml
+++ b/account_payment_batch_oca/views/account_payment_line.xml
@@ -15,10 +15,7 @@
                             invisible="not context.get('account_payment_line_main_view')"
                         />
                         <field name="name" />
-                        <field
-                            name="move_line_id"
-                            domain="[('reconciled','=', False), ('account_id.reconcile', '=', True)] "
-                        />
+                        <field name="move_line_id" />
                         <!-- we removed the filter on amount_to_pay, because we want to be able to select refunds -->
                         <field name="partner_id" />
                         <field

--- a/account_payment_mandate/models/account_payment_line.py
+++ b/account_payment_mandate/models/account_payment_line.py
@@ -36,17 +36,18 @@ class AccountPaymentLine(models.Model):
                     mandate = move.mandate_id
                 elif line.partner_id:
                     mandate = line.partner_id.valid_mandate_id
-            line.mandate_id = mandate and mandate.id or False
+            line.mandate_id = mandate
 
     @api.depends("mandate_id")
-    def _compute_payment_line(self):
-        res = super()._compute_payment_line()
+    def _compute_partner_bank_id(self):
+        res = super()._compute_partner_bank_id()
         for line in self:
-            if line.mandate_id and (
-                not line.partner_bank_id
-                or line.partner_bank_id != line.mandate_id.partner_bank_id
-            ):
-                line.partner_bank_id = line.mandate_id.partner_bank_id.id
+            payment_method = line.order_id.payment_method_id
+            if payment_method.mandate_required:
+                if line.mandate_id:
+                    line.partner_bank_id = line.mandate_id.partner_bank_id
+                else:
+                    line.partner_bank_id = False
         return res
 
     @api.constrains("mandate_id", "partner_bank_id")

--- a/account_payment_mandate/models/account_payment_line.py
+++ b/account_payment_mandate/models/account_payment_line.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import ValidationError
 
 
 class AccountPaymentLine(models.Model):
@@ -72,13 +72,13 @@ class AccountPaymentLine(models.Model):
                     )
                 )
 
-    def draft2open_payment_line_check(self):
-        res = super().draft2open_payment_line_check()
+    def _draft2open_payment_line_check(self):
+        errors = super()._draft2open_payment_line_check()
         if self.mandate_required and not self.mandate_id:
-            raise UserError(
+            errors.append(
                 _("Missing mandate on payment line '%s'.") % self.display_name
             )
-        return res
+        return errors
 
     @api.model
     def _payment_grouping_fields(self):

--- a/account_payment_mandate/tests/test_invoice_mandate.py
+++ b/account_payment_mandate/tests/test_invoice_mandate.py
@@ -22,6 +22,12 @@ class TestInvoiceMandate(AccountTestInvoicingCommon):
         )
         cls.company = cls.company_data["company"]
         cls.company_2 = cls.test_company["company"]
+        cls.product = cls.env["product.product"].create(
+            {
+                "name": "Test Product Mandate",
+                "type": "service",
+            }
+        )
         cls.env.user.write(
             {
                 "groups_id": [
@@ -99,7 +105,7 @@ class TestInvoiceMandate(AccountTestInvoicingCommon):
                 "invoice_line_ids": [
                     Command.create(
                         {
-                            "product_id": cls.env.ref("product.product_product_4").id,
+                            "product_id": cls.product.id,
                             "quantity": 1.0,
                             "price_unit": 200.00,
                         }

--- a/account_payment_mandate/views/account_payment_line.xml
+++ b/account_payment_mandate/views/account_payment_line.xml
@@ -16,7 +16,7 @@
                 <field name="mandate_required" invisible="1" />
                 <field
                     name="mandate_id"
-                    invisible="not mandate_required"
+                    invisible="not mandate_required or not partner_id"
                     required="mandate_required"
                     context="{'default_partner_bank_id': partner_bank_id}"
                 />

--- a/account_payment_sepa_credit_transfer/models/__init__.py
+++ b/account_payment_sepa_credit_transfer/models/__init__.py
@@ -1,3 +1,4 @@
 from . import account_payment_method
 from . import account_payment_order
 from . import account_payment_line
+from . import account_payment

--- a/account_payment_sepa_credit_transfer/models/account_payment.py
+++ b/account_payment_sepa_credit_transfer/models/account_payment.py
@@ -1,0 +1,16 @@
+# Copyright 2025 Akretion France (https://www.akretion.com/)
+# @author: Alexis de Lattre <alexis.delattre@akretion.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from odoo import api, models
+
+
+class AccountPayment(models.Model):
+    _inherit = "account.payment"
+
+    @api.model
+    def _get_method_codes_using_bank_account(self):
+        res = super()._get_method_codes_using_bank_account()
+        res.append("sepa_credit_transfer")
+        return res

--- a/account_payment_sepa_credit_transfer/tests/test_sct.py
+++ b/account_payment_sepa_credit_transfer/tests/test_sct.py
@@ -89,14 +89,18 @@ class TestSCT(AccountTestInvoicingCommon):
                 "allow_out_payment": True,
             }
         )
+        cls.bank1 = cls.env["res.bank"].create(
+            {
+                "name": "Bank Test SCT",
+                "bic": "TESTSEPAXXX",
+            }
+        )
         cls.partner_bank = cls.partner_bank_model.create(
             {
                 "acc_number": "FR0812221333144415551666777",
                 "company_id": cls.company.id,
                 "partner_id": cls.company.partner_id.id,
-                "bank_id": (
-                    cls.env.ref("account_payment_base_oca.bank_la_banque_postale").id
-                ),
+                "bank_id": cls.bank1.id,
                 "allow_out_payment": True,
             }
         )
@@ -139,21 +143,21 @@ class TestSCT(AccountTestInvoicingCommon):
     def check_eur_currency_sct(self):
         invoice1 = self.create_invoice(
             self.partner1.id,
-            "account_payment_base_oca.res_partner_2_iban",
+            self.partner1_bank.id,
             self.eur_currency.id,
             42.0,
             "F1341",
         )
         invoice2 = self.create_invoice(
             self.partner1.id,
-            "account_payment_base_oca.res_partner_2_iban",
+            self.partner1_bank.id,
             self.eur_currency.id,
             12.0,
             "F1342",
         )
         invoice3 = self.create_invoice(
             self.partner1.id,
-            "account_payment_base_oca.res_partner_2_iban",
+            self.partner1_bank.id,
             self.eur_currency.id,
             5.0,
             "A1301",
@@ -161,14 +165,14 @@ class TestSCT(AccountTestInvoicingCommon):
         )
         invoice4 = self.create_invoice(
             self.partner3.id,
-            "account_payment_base_oca.res_partner_12_iban",
+            self.partner3_bank.id,
             self.eur_currency.id,
             11.0,
             "I1642",
         )
         invoice5 = self.create_invoice(
             self.partner3.id,
-            "account_payment_base_oca.res_partner_12_iban",
+            self.partner3_bank.id,
             self.eur_currency.id,
             41.0,
             "I1643",
@@ -254,14 +258,14 @@ class TestSCT(AccountTestInvoicingCommon):
     def test_usd_currency_sct(self):
         invoice1 = self.create_invoice(
             self.partner2.id,
-            "account_payment_base_oca.res_partner_2_iban",
+            self.partner2_bank.id,
             self.usd_currency.id,
             2042.0,
             "Inv9032",
         )
         invoice2 = self.create_invoice(
             self.partner2.id,
-            "account_payment_base_oca.res_partner_2_iban",
+            self.partner2_bank.id,
             self.usd_currency.id,
             1012.0,
             "Inv9033",
@@ -355,14 +359,12 @@ class TestSCT(AccountTestInvoicingCommon):
     def create_invoice(
         cls,
         partner_id,
-        partner_bank_xmlid,
+        partner_bank_id,
         currency_id,
         price_unit,
         reference,
         move_type="in_invoice",
     ):
-        partner_bank = cls.env.ref(partner_bank_xmlid)
-        partner_bank.write({"company_id": False})
         line_data = {
             "name": "Great service",
             "account_id": cls.test_company_dict["default_account_expense"].id,
@@ -377,7 +379,7 @@ class TestSCT(AccountTestInvoicingCommon):
             "invoice_date": time.strftime("%Y-%m-%d"),
             "move_type": move_type,
             "preferred_payment_method_line_id": cls.payment_method_line.id,
-            "partner_bank_id": partner_bank.id,
+            "partner_bank_id": partner_bank_id,
             "company_id": cls.company.id,
             "invoice_line_ids": [Command.create(line_data)],
         }

--- a/account_payment_sepa_direct_debit/models/account_payment_line.py
+++ b/account_payment_sepa_direct_debit/models/account_payment_line.py
@@ -24,52 +24,38 @@ class AccountPaymentLine(models.Model):
                 return False
         return sepa
 
-    def draft2open_payment_line_check(self):
-        res = super().draft2open_payment_line_check()
-        sepa_dd_lines = self.filtered(
-            lambda line: line.order_id.payment_method_id.code == "sepa_direct_debit"
-        )
-        sepa_dd_lines._check_sepa_direct_debit_ready()
-        return res
-
-    def _check_sepa_direct_debit_ready(self):
-        """
-        This method checks whether the payment line(s) are ready to be used
-        in the SEPA Direct Debit file generation.
-        :raise: UserError if a line does not fulfils all requirements
-        """
-        for rec in self:
-            if not rec.mandate_id:
-                raise UserError(
-                    _(
-                        "Missing SEPA Direct Debit mandate on the line with "
-                        "partner {partner_name} (reference {reference})."
-                    ).format(partner_name=rec.partner_id.name, reference=rec.name)
-                )
-            if rec.mandate_id.state not in ("valid", "final"):
-                raise UserError(
+    def _draft2open_payment_line_check(self):
+        errors = super()._draft2open_payment_line_check()
+        # self.mandate_id != False is already checked in account_payment_mandate
+        if (
+            self.order_id.payment_method_id.code == "sepa_direct_debit"
+            and self.mandate_id
+        ):
+            if self.mandate_id.state not in ("valid", "final"):
+                errors.append(
                     _(
                         "The SEPA Direct Debit mandate with reference "
                         "{mandate_ref} for partner {partner_name} has "
                         "expired."
                     ).format(
-                        mandate_ref=rec.mandate_id.unique_mandate_reference,
-                        partner_name=rec.partner_id.name,
+                        mandate_ref=self.mandate_id.unique_mandate_reference,
+                        partner_name=self.partner_id.name,
                     )
                 )
-            if rec.mandate_id.type == "oneoff" and rec.mandate_id.last_debit_date:
-                raise UserError(
+            if self.mandate_id.type == "oneoff" and self.mandate_id.last_debit_date:
+                errors.append(
                     _(
                         "The SEPA Direct Debit mandate with reference "
                         "{mandate_ref} for partner {partner_name} has type set "
                         "to 'One-Off' but has a last debit date set to "
                         "{last_debit_date}. Therefore, it cannot be used."
                     ).format(
-                        mandate_ref=rec.mandate_id.unique_mandate_reference,
-                        partner_name=rec.partner_id.name,
-                        last_debit_date=rec.mandate_id.last_debit_date,
+                        mandate_ref=self.mandate_id.unique_mandate_reference,
+                        partner_name=self.partner_id.name,
+                        last_debit_date=self.mandate_id.last_debit_date,
                     )
                 )
+        return errors
 
     @api.model
     def _lot_grouping_fields(self):

--- a/account_payment_sepa_direct_debit/tests/test_sdd.py
+++ b/account_payment_sepa_direct_debit/tests/test_sdd.py
@@ -69,13 +69,17 @@ class TestSDDBase(AccountTestInvoicingCommon):
                 "partner_id": cls.partner2.id,
             }
         )
+        cls.bank1 = cls.env["res.bank"].create(
+            {
+                "name": "Bank Test SDD",
+                "bic": "TESTSDDXXXX",
+            }
+        )
         cls.company_bank = cls.env["res.partner.bank"].create(
             {
                 "company_id": cls.company.id,
                 "partner_id": cls.company.partner_id.id,
-                "bank_id": (
-                    cls.env.ref("account_payment_base_oca.bank_la_banque_postale").id
-                ),
+                "bank_id": cls.bank1.id,
                 "acc_number": "ES52 0182 2782 5688 3882 1868",
             }
         )


### PR DESCRIPTION
If you have several errors in the same payment line, all the errors will be displayed to the user, not just the first one

Delete account.payment and account.payment.lot on back to draft Remove env.flush_all() in draft2open()

Move the check on 'Disallow Debit Before Maturity Date' in _draft2open_payment_line_check()

draft2open_payment_line_check() is now a private method