### PR TITLE
[18.0][FIX] Fix 'name' key in manifest

### DIFF
--- a/account_payment_sepa_credit_transfer/__manifest__.py
+++ b/account_payment_sepa_credit_transfer/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
 {
-    "name": "Account Banking SEPA Credit Transfer",
+    "name": "Account Payment SEPA Credit Transfer",
     "summary": "Create SEPA XML files for Credit Transfers",
     "version": "18.0.3.0.0",
     "license": "AGPL-3",

--- a/account_payment_sepa_direct_debit/__manifest__.py
+++ b/account_payment_sepa_direct_debit/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
-    "name": "Account Banking SEPA Direct Debit",
+    "name": "Account Payment SEPA Direct Debit",
     "summary": "Create SEPA files for Direct Debit",
     "version": "18.0.3.0.0",
     "license": "AGPL-3",


### PR DESCRIPTION
Update 'name' key of the manifest of
account_payment_sepa_credit_transfer and
account_payment_sepa_direct_debit, to make it easier to differenciate with OCA/bank-payment