### PR TITLE
[18.0][IMP] account_payment_batch_oca: add journal_id on account.payment.lot

### DIFF
--- a/account_payment_batch_oca/models/account_payment_lot.py
+++ b/account_payment_batch_oca/models/account_payment_lot.py
@@ -19,10 +19,12 @@ class AccountPaymentLot(models.Model):
         required=True,
         check_company=True,
         index=True,
+        readonly=True,
     )
     payment_type = fields.Selection(related="order_id.payment_type", store=True)
     state = fields.Selection(related="order_id.state", store=True)
     company_id = fields.Many2one(related="order_id.company_id", store=True)
+    journal_id = fields.Many2one(related="order_id.journal_id", store=True)
     date = fields.Date(required=True, string="Execution Date", readonly=True)
     currency_id = fields.Many2one("res.currency", readonly=True)
     amount = fields.Monetary(compute="_compute_payment_lot", store=True)

--- a/account_payment_batch_oca/views/account_payment_lot.xml
+++ b/account_payment_batch_oca/views/account_payment_lot.xml
@@ -19,6 +19,10 @@
                         name="order_id"
                         invisible="not context.get('account_payment_lot_main_view')"
                     />
+                    <field
+                        name="journal_id"
+                        invisible="not context.get('account_payment_lot_main_view')"
+                    />
                     <field name="date" />
                     <field name="amount" />
                     <field name="currency_id" invisible="1" />
@@ -40,6 +44,11 @@
                     column_invisible="not context.get('account_payment_lot_main_view')"
                 />
                 <field name="name" decoration-bf="1" />
+                <field
+                    name="journal_id"
+                    column_invisible="not context.get('account_payment_lot_main_view')"
+                    optional="hide"
+                />
                 <field name="date" />
                 <field name="amount" />
                 <field name="payment_count" string="Payments" />
@@ -53,6 +62,7 @@
         <field name="arch" type="xml">
             <search>
                 <field name="name" />
+                <field name="journal_id" />
                 <separator />
                 <filter
                     name="inbound"
@@ -72,6 +82,11 @@
                         string="Payment Order"
                         context="{'group_by': 'order_id'}"
                     />
+                    <filter
+                        name="journal_groupby"
+                        string="Bank Journal"
+                        context="{'group_by': 'journal_id'}"
+                    />
                 </group>
             </search>
         </field>
@@ -81,5 +96,6 @@
         <field name="name">Payment Lots</field>
         <field name="res_model">account.payment.lot</field>
         <field name="view_mode">list,form</field>
+        <field name="context">{'account_payment_lot_main_view': True}</field>
     </record>
 </odoo>


### PR DESCRIPTION
This new related field journal_id on account.payment.lot is needed by the module account_reconcile_payment_batch_oca and can be useful for other modules too.
Field order_id on account.payment.lot is now readonly.