### PR TITLE
[18.0][IMP] account_payment_base_oca: hide field payment_account_id when bank_account_link = 'variable'

### DIFF
--- a/account_payment_base_oca/models/account_payment_method_line.py
+++ b/account_payment_base_oca/models/account_payment_method_line.py
@@ -6,7 +6,7 @@
 
 
 from odoo import Command, _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 
 class AccountPaymentMethodLine(models.Model):
@@ -159,7 +159,7 @@ class AccountPaymentMethodLine(models.Model):
             if line.bank_account_link == "variable" and line.payment_account_id:
                 raise ValidationError(
                     _(
-                        "The payment method %(name)s has a variable link to a bank "
+                        "The payment method '%(name)s' has a variable link to a bank "
                         "account, so it should not have an outstanding payment/receipt "
                         "account. Only payment methods with a fixed link to a "
                         "bank account can have one.",
@@ -208,3 +208,19 @@ class AccountPaymentMethodLine(models.Model):
                 line.display_name = f"{line.name} ({line.journal_id.name})"
             else:
                 line.display_name = f"{line.name}"
+
+    def write(self, vals):
+        if vals.get("bank_account_link") == "variable":
+            for line in self:
+                if line.bank_account_link == "fixed":
+                    raise UserError(
+                        _(
+                            "You should not edit the payment method '%(name)s' "
+                            "to change it from a fixed bank account link to "
+                            "a variable bank account link. You should "
+                            "create a new payment method with a variable "
+                            "bank account link.",
+                            name=line.display_name,
+                        )
+                    )
+        return super().write(vals)

--- a/account_payment_base_oca/models/account_payment_method_line.py
+++ b/account_payment_base_oca/models/account_payment_method_line.py
@@ -28,6 +28,9 @@ class AccountPaymentMethodLine(models.Model):
         precompute=True,
         readonly=False,
     )
+    payment_account_id = fields.Many2one(  # that field doesn't have a native string
+        string="Outstanding Payment/Receipt Account"
+    )
     # END inherit of native fields
     # Here is the strategy to support bank_account_link = variable
     # without breaking the native behavior
@@ -111,6 +114,7 @@ class AccountPaymentMethodLine(models.Model):
         "journal_id",
         "variable_journal_ids",
         "payment_method_id",
+        "payment_account_id",
     )
     def _check_payment_method_line(self):
         for line in self:
@@ -152,6 +156,16 @@ class AccountPaymentMethodLine(models.Model):
                                     journal=journal.display_name,
                                 )
                             )
+            if line.bank_account_link == "variable" and line.payment_account_id:
+                raise ValidationError(
+                    _(
+                        "The payment method %(name)s has a variable link to a bank "
+                        "account, so it should not have an outstanding payment/receipt "
+                        "account. Only payment methods with a fixed link to a "
+                        "bank account can have one.",
+                        name=line.display_name,
+                    )
+                )
 
     @api.depends("bank_account_link")
     def _compute_variable_journal_ids(self):

--- a/account_payment_base_oca/views/account_payment_method_line.xml
+++ b/account_payment_base_oca/views/account_payment_method_line.xml
@@ -54,7 +54,16 @@
                             string="Default Journal"
                         />
                         <field name="refund_payment_method_line_id" />
-                        <field name="payment_account_id" />
+                        <field
+                            name="payment_account_id"
+                            invisible="bank_account_link != 'fixed' or payment_type != 'outbound'"
+                            string="Outstanding Payment Account"
+                        />
+                        <field
+                            name="payment_account_id"
+                            invisible="bank_account_link != 'fixed' or payment_type != 'inbound'"
+                            string="Outstanding Receipt Account"
+                        />
                         <field name="company_id" groups="base.group_multi_company" />
                         <field name="default_account_id" invisible="1" />
                         <field name="filter_journal_ids" invisible="1" />
@@ -108,8 +117,13 @@
                 <attribute name="decoration-bf">1</attribute>
             </field>
             <field name="journal_id" position="after">
+                <field name="payment_account_id" optional="hide" />
                 <field name="selectable" widget="boolean_toggle" />
-                <field name="company_id" groups="base.group_multi_company" />
+                <field
+                    name="company_id"
+                    groups="base.group_multi_company"
+                    optional="show"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
Add payment_account_id in list view of account.payment.method.line. Add constraint to block when someone configures an outstanding account on a payment method line with bank_account_link = 'variable'