### PR TITLE
[18] Add migration scrips

### DIFF
--- a/account_payment_base_oca/migrations/18.0.1.0.0/post-migrate.py
+++ b/account_payment_base_oca/migrations/18.0.1.0.0/post-migrate.py
@@ -2,7 +2,7 @@
 
 import json
 
-from openupgradelib import openupgrade
+from openupgradelib import openupgrade, openupgrade_180
 
 
 @openupgrade.migrate()
@@ -96,7 +96,6 @@ def migrate(env, version):
         WHERE account_payment_method_line.old_refund_payment_mode_id IS NOT NULL
         AND account_payment_method_line.old_refund_payment_mode_id = apml2.old_payment_mode_id
     """)  # noqa: E501
-    # TODO migrate supplier_payment_mode_id and customer_payment_mode_id
     env.cr.execute("""
         UPDATE account_move
         SET preferred_payment_method_line_id = apml.id
@@ -105,3 +104,29 @@ def migrate(env, version):
         AND apm.id = apml.old_payment_mode_id
         AND account_move.preferred_payment_method_line_id IS NULL
     """)
+    mapping_expression = """
+        (SELECT apml.id
+         FROM account_payment_method_line apml
+         WHERE apml.old_payment_mode_id = SPLIT_PART(value_reference, ',', 2)::integer
+         LIMIT 1)
+    """
+    old_supplier_field_id = env.ref(
+        "account_payment_base_oca.field_res_partner__supplier_payment_mode_id"
+    ).id
+    old_customer_field_id = env.ref(
+        "account_payment_base_oca.field_res_partner__customer_payment_mode_id"
+    ).id
+    openupgrade_180.convert_company_dependent(
+        env,
+        "res.partner",
+        "property_outbound_payment_method_line_id",
+        value_expression=mapping_expression,
+        old_field_id=old_supplier_field_id,
+    )
+    openupgrade_180.convert_company_dependent(
+        env,
+        "res.partner",
+        "property_inbound_payment_method_line_id",
+        value_expression=mapping_expression,
+        old_field_id=old_customer_field_id,
+    )

--- a/account_payment_base_oca/migrations/18.0.1.0.0/post-migrate.py
+++ b/account_payment_base_oca/migrations/18.0.1.0.0/post-migrate.py
@@ -1,0 +1,107 @@
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+import json
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env.cr.execute("""
+        ALTER TABLE account_payment_method_line
+        ADD column old_payment_mode_id int,
+        ADD COLUMN old_refund_payment_mode_id int
+    """)
+    env.cr.execute("""
+        SELECT id,
+               name,
+               company_id,
+               payment_method_id,
+               fixed_journal_id as journal_id,
+               bank_account_link,
+               create_date,
+               create_uid,
+               write_date,
+               write_uid,
+               show_bank_account,
+               refund_payment_mode_id,
+               active
+        from account_payment_mode
+    """)
+    payment_mode_info = env.cr.dictfetchall()
+    for params in payment_mode_info:
+        params["name"] = json.dumps(params["name"])
+        params["selectable"] = True
+        mode_id = params.pop("id")
+        refund_mode_id = params.pop("refund_payment_mode_id")
+        params["old_payment_mode_id"] = mode_id
+        params["old_refund_payment_mode_id"] = refund_mode_id
+        method_id = env.cr.execute(
+            """insert into account_payment_method_line (
+            name,
+            payment_method_id,
+            bank_account_link,
+            journal_id,
+            selectable,
+            company_id,
+            create_uid,
+            create_date,
+            write_uid,
+            write_date,
+            show_bank_account,
+            old_payment_mode_id,
+            old_refund_payment_mode_id,
+            active
+        )
+        values (
+            %(name)s,
+            %(payment_method_id)s,
+            %(bank_account_link)s,
+            %(journal_id)s,
+            %(selectable)s,
+            %(company_id)s,
+            %(create_uid)s,
+            %(create_date)s,
+            %(write_uid)s,
+            %(write_date)s,
+            %(show_bank_account)s,
+            %(old_payment_mode_id)s,
+            %(old_refund_payment_mode_id)s,
+            %(active)s
+        ) RETURNING id
+        """,
+            params,
+        )
+        # get variable journals
+        env.cr.execute(
+            """
+            SELECT rel.journal_id
+            FROM account_payment_mode m
+            JOIN account_payment_mode_variable_journal_rel rel
+            ON rel.payment_mode_id = %s
+            WHERE bank_account_link = 'variable'
+        """,
+            (method_id,),
+        )
+        journal_ids = [x[0] for x in env.cr.fetchall()]
+        if journal_ids:
+            env["account.payment.method.line"].browse(method_id).write(
+                {"variable_journal_ids": journal_ids}
+            )
+
+    env.cr.execute("""
+        UPDATE account_payment_method_line
+        SET refund_payment_method_line_id = apml2.id
+        FROM account_payment_method_line apml2
+        WHERE account_payment_method_line.old_refund_payment_mode_id IS NOT NULL
+        AND account_payment_method_line.old_refund_payment_mode_id = apml2.old_payment_mode_id
+    """)  # noqa: E501
+    # TODO migrate supplier_payment_mode_id and customer_payment_mode_id
+    env.cr.execute("""
+        UPDATE account_move
+        SET preferred_payment_method_line_id = apml.id
+        FROM account_payment_mode apm, account_payment_method_line apml
+        WHERE account_move.payment_mode_id = apm.id
+        AND apm.id = apml.old_payment_mode_id
+        AND account_move.preferred_payment_method_line_id IS NULL
+    """)

--- a/account_payment_base_oca/migrations/18.0.1.0.0/pre-migrate.py
+++ b/account_payment_base_oca/migrations/18.0.1.0.0/pre-migrate.py
@@ -1,0 +1,14 @@
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env.cr.execute("""
+        UPDATE ir_model_data
+        SET noupdate = false
+        WHERE module = 'account_payment_base_oca'
+        AND name = 'view_account_invoice_report_search'
+    """)

--- a/account_payment_batch_oca/migrations/18.0.1.0.0/post-migrate.py
+++ b/account_payment_batch_oca/migrations/18.0.1.0.0/post-migrate.py
@@ -1,0 +1,70 @@
+#  License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+from openupgradelib import openupgrade
+
+from odoo.fields import first
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env.cr.execute("""
+        UPDATE account_payment_method
+        SET payment_order_ok = payment_order_only
+    """)
+    env.cr.execute("""
+        UPDATE account_payment_method_line
+        SET payment_order_ok = apm.payment_order_ok,
+            no_debit_before_maturity = apm.no_debit_before_maturity,
+            default_payment_mode = apm.default_payment_mode,
+            default_invoice = apm.default_invoice,
+            default_target_move = apm.default_target_move,
+            default_date_type = apm.default_date_type,
+            default_date_prefered = apm.default_date_prefered,
+            group_lines = apm.group_lines
+        FROM account_payment_mode apm
+        WHERE account_payment_method_line.old_payment_mode_id IS NOT NULL
+        AND apm.id = account_payment_method_line.old_payment_mode_id
+    """)
+    # manage default_journal_ids
+    # remove default computed values
+    env.cr.execute("DELETE FROM account_journal_account_payment_mode_rel")
+    # fill from old payment mode table
+    env.cr.execute("""
+        INSERT INTO account_journal_account_payment_method_line_rel
+            (account_payment_method_line_id, account_journal_id)
+        SELECT
+            t2.id,
+            t1.account_journal_id
+        FROM
+            account_journal_account_payment_mode_rel AS t1
+        JOIN
+            account_payment_method_line AS t2
+            ON t1.account_payment_mode_id = t2.old_payment_mode_id;
+    """)
+
+    env.cr.execute("""
+        UPDATE account_payment_order
+        SET payment_method_line_id = apml.id,
+            payment_method_code = account_payment_method.code
+        FROM account_payment_method_line apml,
+             account_payment_mode apm,
+             account_payment_method
+        WHERE account_payment_order.payment_mode_id = apm.id
+        AND apml.old_payment_mode_id = apm.id
+        AND account_payment_method.id = apml.payment_method_id
+    """)
+
+    # generate lot for confirmed payment orders
+    for order in env["account.payment.order"].search([("state", "=", "open")]):
+        lots = {}
+        for payment in order.payment_ids:
+            payment_line = first(payment.payment_line_ids)
+            if not payment_line:
+                continue
+            lot_key = payment_line._lot_grouping_key()
+            if lot_key not in lots:
+                lots[lot_key] = env["account.payment.lot"].create(
+                    payment_line._prepare_account_payment_lot_vals(len(lot_key) + 1)
+                )
+            payment.write({"payment_lot_id": lots[lot_key].id})

--- a/account_payment_batch_oca/migrations/18.0.1.0.0/post-migrate.py
+++ b/account_payment_batch_oca/migrations/18.0.1.0.0/post-migrate.py
@@ -55,6 +55,14 @@ def migrate(env, version):
         AND account_payment_method.id = apml.payment_method_id
     """)
 
+    env.cr.execute(
+        "UPDATE account_move SET reference_type='free' WHERE reference_type='none'"
+    )
+    env.cr.execute(
+        "UPDATE account_payment_line SET communication_type='free' "
+        "WHERE communication_type='normal'"
+    )
+
     # generate lot for confirmed payment orders
     for order in env["account.payment.order"].search([("state", "=", "open")]):
         lots = {}


### PR DESCRIPTION
Hello,

I did start some migration script to go from v17 bank-payment toward bank-payment-alternative.
I am not sure on the right way to go on this one though, so it is just a first imperfect proposal, feel free to suggest anything or do in an other way.

Since the bank-payment and bank-payment-alternative modules can't be installed together (excluded in manifest), I did rename the modules in apriori openupgrade file (which I can't contribute, obviously, it must be define in every project to migrate)
renamed modules
```
    "account_payment_mode": "account_payment_base_oca",
    "account_banking_pain_base": "account_payment_sepa_base",
    "account_banking_sepa_credit_transfer": "account_payment_sepa_credit_transfer",
    "account_payment_order": "account_payment_batch_oca",
```
merged module : 
`    "account_payment_partner": "account_payment_base_oca",`

Once the renamed is done, the scripts should run smoothly.
Migration of customer_payment_mode_id and supplier_payment_mode_id is still to do

If we decide to go forward with this method, I could split it to have a PR by module.

FYI @alexis-via @sbidoul 