### PR TITLE
[18.0][IMP] account_payment_sepa_base: Add party org identification in SEPA XML for companies with VAT number

### DIFF
--- a/account_payment_sepa_base/models/res_partner.py
+++ b/account_payment_sepa_base/models/res_partner.py
@@ -180,4 +180,10 @@ class ResPartner(models.Model):
         at the company or payment method level.
         """
         self.ensure_one()
-        return
+        if self.is_company and self.vat:
+            id_node = objectify.SubElement(parent_node, "Id")
+            org_id_node = objectify.SubElement(id_node, "OrgId")
+            other_node = objectify.SubElement(org_id_node, "Othr")
+            other_node.Id = self.vat
+            scheme_name_node = objectify.SubElement(other_node, "SchmeNm")
+            scheme_name_node.Cd = "TXID"


### PR DESCRIPTION
Generated XML:

```
<Dbtr>
  <Nm>My Company (San Francisco)</Nm>
  <PstlAdr>
    <StrtNm>Executive Park Blvd Suite 3400</StrtNm>
    <BldgNb>250</BldgNb>
    <PstCd>94134</PstCd>
    <TwnNm>San Francisco</TwnNm>
    <CtrySubDvsn>California</CtrySubDvsn>
    <Ctry>FR</Ctry>
  </PstlAdr>
  <Id>
    <OrgId>
      <Othr>
        <Id>FR58441019213</Id>
        <SchmeNm>
          <Cd>TXID</Cd>
        </SchmeNm>
      </Othr>
    </OrgId>
  </Id>
</Dbtr>
```

Same for creditor.

Writing VAT numbers for organisations is recommended for VOP (Verification of Payee).