### PR TITLE
[19.0][FIX] account_payment_sepa_base: 2 fw-ports: hybrid address format + VAT number

### DIFF
--- a/account_payment_batch_oca/data/mail_template.xml
+++ b/account_payment_batch_oca/data/mail_template.xml
@@ -11,11 +11,11 @@
             name="model_id"
             ref="account_payment_batch_oca.model_account_payment_order"
         />
-        <field name="lang">{{ ctx['partner_lang'] }}</field>
+        <field name="lang">{{ ctx.get('partner_lang') }}</field>
         <field
             name="email_from"
         >{{ object.company_id.email_formatted or user.email_formatted }}</field>
-        <field name="partner_to">{{ ctx['partner_to'] }}</field>
+        <field name="partner_to">{{ ctx.get('partner_to') }}</field>
         <field name="auto_delete" eval="True" />
         <field
             name="subject"
@@ -39,7 +39,7 @@
                 >debit(s)</t><t
                     t-if="object.payment_type == 'outbound'"
                 >payment(s)</t> below for <strong>
-                    <t t-out="ctx['partner_display_name']">Azur Interior</t>
+                    <t t-out="ctx.get('partner_display_name')">Azur Interior</t>
                 </strong>.</p>
                 <table
                     style="border-spacing: 0; border-collapse: collapse; width: 100%; text-align: center;"
@@ -53,7 +53,7 @@
                         <th style="padding: 5px; border: 2px solid black;">Amount</th>
                         <th
                             style="padding: 5px; border: 2px solid black;"
-                            t-if="ctx['detail_col']"
+                            t-if="ctx.get('detail_col')"
                         >Details</th>
                         <th style="padding: 5px; border: 2px solid black;">
                             <t
@@ -64,7 +64,7 @@
                             >Destination Bank Account</t>
                         </th>
                     </tr>
-                    <t t-foreach="ctx['payments']" t-as="payment">
+                    <t t-foreach="ctx.get('payments')" t-as="payment">
                         <tr>
                             <td
                                 style="padding: 5px; border: 2px solid black; text-align: center;"
@@ -83,7 +83,7 @@
                             </td>
                             <td
                                 style="padding: 5px; border: 2px solid black;"
-                                t-if="ctx['detail_col']"
+                                t-if="ctx.get('detail_col')"
                             >
                                 <table
                                     t-if="payment['lines']"

--- a/account_payment_sepa_base/models/res_partner.py
+++ b/account_payment_sepa_base/models/res_partner.py
@@ -44,12 +44,25 @@ class ResPartner(models.Model):
                 )
             postal_address.Ctry = self.country_id.code
             if self.street:
-                postal_address.AdrLine = apoo._prepare_field(
-                    "Street as Address Line 1", self.street, 70, gen_args
+                adrline1 = objectify.SubElement(postal_address, "AdrLine")
+                adrline1._setText(
+                    apoo._prepare_field(
+                        "Street as Address Line 1", self.street, 70, gen_args
+                    )
                 )
             if self.street2:
-                postal_address.AdrLine = apoo._prepare_field(
-                    "Street2 as Address Line 2", self.street2, 70, gen_args
+                # EPC says in
+                # https://www.europeanpaymentscouncil.eu/sites/default/files/kb/file/2025-10/EPC153-22%20v2.1%20EPC%20guidance%20document%20-%20Provision%20of%20Addresses%20under%20the%20EPC%20Payment%20Schemes.pdf
+                # that we can only have 2 occurences of AdrLine
+                adrline2_val = self.street2
+                # if module OCA/partner-contact/partner_address_street3 is installed
+                if hasattr(self, "street3") and self.street3:
+                    adrline2_val = " - ".join([adrline2_val, self.street3])
+                adrline2 = objectify.SubElement(postal_address, "AdrLine")
+                adrline2._setText(
+                    apoo._prepare_field(
+                        "Street2 as Address Line 2", adrline2_val, 70, gen_args
+                    )
                 )
 
     def _generate_unstructured_address_block(self, parent_node, gen_args):

--- a/account_payment_sepa_base/models/res_partner.py
+++ b/account_payment_sepa_base/models/res_partner.py
@@ -3,11 +3,10 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import logging
-import re
 
 from lxml import objectify
 
-from odoo import api, models
+from odoo import models
 
 logger = logging.getLogger(__name__)
 
@@ -20,54 +19,17 @@ class ResPartner(models.Model):
         Following EPC guidelines:
         https://www.europeanpaymentscouncil.eu/document-library/guidance-documents/
         guidance-use-structured-addresses-2025-sepa-payment-schemes
+        Apart from PAIN flavors that only support the unstructured address format,
+        we use the hybrid format because it is the most appropriate for the native
+        Odoo datamodel (allowed since October 5th 2025)
         """
         self.ensure_one()
         if gen_args["pain_flavor"].startswith(("pain.001.003.03", "pain.008.003.02")):
+            # only for german-specific PAIN variants
             return self._generate_unstructured_address_block(parent_node, gen_args)
         apoo = self.env["account.payment.order"]
         if self.country_id:
             postal_address = objectify.SubElement(parent_node, "PstlAdr")
-            street = self.street
-            street2 = self.street2
-            if street2 and not street:
-                street = street2
-                street2 = False
-            if street2 and gen_args["pain_flavor"].startswith("pain.001.001.03"):
-                postal_address.Dept = apoo._prepare_field(
-                    "Department (Street 2)", street2, 70, gen_args
-                )
-            if street:
-                # fields added by official module 'base_address_extended'
-                if (
-                    hasattr(self, "street_name")
-                    and hasattr(self, "street_number")
-                    and hasattr(self, "street_number2")
-                ):
-                    street_name = self.street_name
-                    street_number = self.street_number
-                    door = self.street_number2
-                else:
-                    # I don't use tools.street_split() because it doesn't work in many
-                    # scenarios for example, in France, street are usually written as:
-                    # 27, rue Henri Rolland
-                    # but tools.street_split() only works when street number is written
-                    # at the end, so I added a method _improved_street_split() below
-                    street_name, street_number = self._improved_street_split(
-                        self.street
-                    )
-                    door = False
-                if street_name:
-                    postal_address.StrtNm = apoo._prepare_field(
-                        "Street Name", street_name, 70, gen_args
-                    )
-                if street_number:
-                    postal_address.BldgNb = apoo._prepare_field(
-                        "Street Number", street_number, 16, gen_args
-                    )
-                if door:
-                    postal_address.Room = apoo._prepare_field(
-                        "Door", door, 70, gen_args
-                    )
             if self.zip:
                 postal_address.PstCd = apoo._prepare_field(
                     "ZIP Code", self.zip, 16, gen_args
@@ -76,80 +38,19 @@ class ResPartner(models.Model):
                 postal_address.TwnNm = apoo._prepare_field(
                     "City", self.city, 35, gen_args
                 )
-            if street2 and gen_args["pain_flavor"].startswith("pain.001.001.09"):
-                postal_address.TwnLctnNm = apoo._prepare_field(
-                    "Town Location Name (Street 2)", street2, 35, gen_args
-                )
             if self.state_id:
-                # Better to write state name in the lang of the partner
-                # for example: for a US partner, we should write its state name
-                # in English and not in the user's lang
                 postal_address.CtrySubDvsn = apoo._prepare_field(
-                    "State",
-                    self.with_context(
-                        lang=self.lang or self.env.user.lang
-                    ).state_id.name,
-                    35,
-                    gen_args,
+                    "State", self.state_id.name, 35, gen_args
                 )
-
             postal_address.Ctry = self.country_id.code
-
-    @api.model
-    def _improved_street_split(self, street):
-        # This method is fully tested in tests/test_pain.py
-        logger.debug("_improved_street_split called on '%s'", street)
-        street = street and street.strip()
-        if not street:
-            return (False, False)
-        street = street.replace(",", " ")
-        street = street.replace(".", " ")
-        # replace all multi-spaces by one space
-        street = " ".join(street.split())
-
-        street_split = street.split(" ")
-        # Handle '22 bis rue Henri Rolland' and 'Edmond street 48 B'
-        if len(street_split) > 2:
-            if street_split[
-                0
-            ].isdigit() and self._improved_street_split_street_number_ext(
-                street_split[1]
-            ):
-                street_name = " ".join(street_split[2:])
-                street_number = " ".join(street_split[:2])
-                return (street_name, street_number)
-            elif street_split[
-                -2
-            ].isdigit() and self._improved_street_split_street_number_ext(
-                street_split[-1]
-            ):
-                street_name = " ".join(street_split[:-2])
-                street_number = " ".join(street_split[-2:])
-                return (street_name, street_number)
-
-        # Search street number in first and last block: it just has to start by a digit
-        if street_split[0][0].isdigit():
-            street_number = street_split[0]
-            street_name = " ".join(street_split[1:])
-        elif street_split[-1][0].isdigit():
-            street_number = street_split[-1]
-            street_name = " ".join(street_split[:-1])
-        else:
-            street_number = False
-            street_name = street
-        return (street_name, street_number)
-
-    @api.model
-    def _improved_street_split_street_number_ext(self, text):
-        # text is already stripped
-        assert text
-        if not re.match(r"[a-zA-Z]", text):
-            return False
-        if len(text) == 1:
-            return True
-        if text.lower() in ("bis", "ter", "quarter"):
-            return True
-        return False
+            if self.street:
+                postal_address.AdrLine = apoo._prepare_field(
+                    "Street as Address Line 1", self.street, 70, gen_args
+                )
+            if self.street2:
+                postal_address.AdrLine = apoo._prepare_field(
+                    "Street2 as Address Line 2", self.street2, 70, gen_args
+                )
 
     def _generate_unstructured_address_block(self, parent_node, gen_args):
         """Generation of unstructured address block is deprecated according to EPC

--- a/account_payment_sepa_base/models/res_partner.py
+++ b/account_payment_sepa_base/models/res_partner.py
@@ -81,4 +81,10 @@ class ResPartner(models.Model):
         at the company or payment method level.
         """
         self.ensure_one()
-        return
+        if self.is_company and self.vat:
+            id_node = objectify.SubElement(parent_node, "Id")
+            org_id_node = objectify.SubElement(id_node, "OrgId")
+            other_node = objectify.SubElement(org_id_node, "Othr")
+            other_node.Id = self.vat
+            scheme_name_node = objectify.SubElement(other_node, "SchmeNm")
+            scheme_name_node.Cd = "TXID"

--- a/account_payment_sepa_base/tests/test_pain.py
+++ b/account_payment_sepa_base/tests/test_pain.py
@@ -64,37 +64,3 @@ class TestAccountBankingPainBase(TransactionCase):
             self.pay_obj._prepare_field(
                 "TEST", "1234567", 5, gen_args, raise_if_oversized=True
             )
-
-    def test_improved_street_split(self):
-        street2res = {
-            " 7 rue Henri Rolland ": ("rue Henri Rolland", "7"),
-            "27, rue Henri Rolland": ("rue Henri Rolland", "27"),
-            "27,rue Henri Rolland": ("rue Henri Rolland", "27"),
-            "55A rue du Tonkin": ("rue du Tonkin", "55A"),
-            "55 A rue du Tonkin": ("rue du Tonkin", "55 A"),
-            "55.A rue du Tonkin": ("rue du Tonkin", "55 A"),
-            "35bis, rue Montgolfier": ("rue Montgolfier", "35bis"),
-            "35 bis, rue Montgolfier": ("rue Montgolfier", "35 bis"),
-            "35BIS, rue Montgolfier": ("rue Montgolfier", "35BIS"),
-            "35 BIS rue Montgolfier": ("rue Montgolfier", "35 BIS"),
-            "27ter, rue René Coty": ("rue René Coty", "27ter"),
-            "27 Quarter rue René Coty": ("rue René Coty", "27 Quarter"),
-            "1242 chemin des Bauges": ("chemin des Bauges", "1242"),
-            "12242 RD 123": ("RD 123", "12242"),
-            "122 rue du Général de division Tartempion": (
-                "rue du Général de division Tartempion",
-                "122",
-            ),
-            "Kirchenstrasse 177": ("Kirchenstrasse", "177"),
-            "Place des Carmélites": ("Place des Carmélites", False),
-            "123 Bismark avenue": ("Bismark avenue", "123"),
-            "34 av Barthelemy Buyer": ("av Barthelemy Buyer", "34"),
-            "4 bd des Belges": ("bd des Belges", "4"),
-            "  ": (False, False),
-        }
-        for street, (exp_street_name, exp_street_number) in street2res.items():
-            street_name, street_number = self.env["res.partner"]._improved_street_split(
-                street
-            )
-            self.assertEqual(street_name, exp_street_name)
-            self.assertEqual(street_number, exp_street_number)


### PR DESCRIPTION
Hybrid address format is allowed since October 5 2025 ; we now use it by default because it more appropriate for the default odoo datamodel.

It fixes a bug when using pain.001.001.03 along with the module base_address_extended: the Room tag doesn't exist in pain.001.001.03.

This is a forwrad-port of https://github.com/OCA/bank-payment-alternative/pull/59