### PR TITLE
[FIX] account_payment_batch_oca: fix french translation error

### DIFF
--- a/account_payment_batch_oca/i18n/fr.po
+++ b/account_payment_batch_oca/i18n/fr.po
@@ -958,8 +958,8 @@ msgid ""
 "No handler for payment method code '%s'. Maybe you haven't installed the "
 "related Odoo module."
 msgstr ""
-"Aucun gestionnaire pour ce mode de paiement. Vous n'avez peut-être pas "
-"installé le module Odoo associé."
+"Aucun gestionnaire pour le code de méthode de paiement '%s'. Peut-être "
+"n'avez-vous pas installé le module Odoo correspondant."
 
 #. module: account_payment_batch_oca
 #. odoo-python


### PR DESCRIPTION
Add the missing '%s' placeholder in the French translation of the UserError raised when a payment method lacks a handler.

Without this placeholder, triggering the error results in a hard server crash (TypeError: not all arguments converted during string formatting) instead of displaying the intended warning message to the user.