### PR TITLE
[IMP] account_payment_base_oca: invoice payment method - add no create/open

### DIFF
--- a/account_payment_base_oca/views/account_move.xml
+++ b/account_payment_base_oca/views/account_move.xml
@@ -39,12 +39,14 @@
                     string="Payment Method"
                     domain="[('payment_type', '=', 'inbound'), ('company_id', '=', company_id), ('selectable', '=', True)]"
                     invisible="move_type in ('in_invoice', 'in_refund')"
+                    options="{'no_open': True, 'no_create': True}"
                 />
                 <field
                     name="preferred_payment_method_line_id"
                     string="Payment Method"
                     domain="[('payment_type', '=', 'outbound'), ('company_id', '=', company_id), ('selectable', '=', True)]"
                     invisible="move_type in ('out_invoice', 'out_refund')"
+                    options="{'no_open': True, 'no_create': True}"
                 />
             </field>
         </field>


### PR DESCRIPTION
Prevent to open/create the payment method from the invoice. Like it is already in standard on the partner.

cc @alexis-via @florian-dacosta 