### PR TITLE
[FIX] account_payment_mandate: bank creation

### DIFF
--- a/account_payment_mandate/views/account_banking_mandate.xml
+++ b/account_payment_mandate/views/account_banking_mandate.xml
@@ -103,6 +103,7 @@
                             <field
                                 name="partner_bank_id"
                                 options="{'create_name_field': 'acc_number'}"
+                                context="{'default_partner_id': partner_id}"
                                 invisible="context.get('mandate_bank_partner_view') or not partner_id"
                             />
                             <field


### PR DESCRIPTION
When creating a bank mandate, after filling the partner, you can fill the bank account. However, this crashes as a bank account requires a partner and the partner selected just before is not propagated.

Fix error:
```
File "/odoo/addons/account/models/res_partner_bank.py", line 305, in create
    account.partner_id._message_log(body=msg)
  File "/odoo/addons/mail/models/mail_thread.py", line 2821, in _message_log
    self.ensure_one()
  File "/odoo/odoo/models.py", line 6277, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: res.partner()
```

cc @alexis-via @florian-dacosta @sebalix 