### PR TITLE
[19.0][IMP] account_payment_batch_oca: make upload notification templ…

### DIFF
--- a/account_payment_batch_oca/README.rst
+++ b/account_payment_batch_oca/README.rst
@@ -115,6 +115,7 @@ Contributors
   - Ammar Officewala <aofficewala@opensourceintegrators.com>
 
 - Marçal Isern <marsal.isern@qubiq.es>
+- Samir GUESMI <samir.guesmi@acsone.eu>
 
 Maintainers
 -----------

--- a/account_payment_batch_oca/__manifest__.py
+++ b/account_payment_batch_oca/__manifest__.py
@@ -10,7 +10,7 @@
 {
     "name": "Account Payment Batch OCA",
     "summary": "Add payment orders and debit orders",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.1.0",
     "license": "AGPL-3",
     "author": "ACSONE SA/NV, "
     "Therp BV, "

--- a/account_payment_batch_oca/migrations/19.0.2.1.0/post-migration.py
+++ b/account_payment_batch_oca/migrations/19.0.2.1.0/post-migration.py
@@ -1,0 +1,12 @@
+def migrate(cr, version):
+    cr.execute(
+        """
+        UPDATE account_payment_method_line AS method_line
+        SET order_uploaded_mail_template_id = model_data.res_id
+        FROM ir_model_data AS model_data
+        WHERE model_data.module = 'account_payment_batch_oca'
+            AND model_data.name = 'payment_order_mail_notif'
+            AND model_data.model = 'mail.template'
+            AND method_line.order_uploaded_mail_template_id IS NULL
+        """
+    )

--- a/account_payment_batch_oca/models/account_payment_method_line.py
+++ b/account_payment_batch_oca/models/account_payment_method_line.py
@@ -99,6 +99,17 @@ class AccountPaymentMethodLine(models.Model):
         help="If enabled, Odoo will automatically notify the partner by email when "
         "the payment/debit order file is successfully uploaded.",
     )
+    order_uploaded_mail_template_id = fields.Many2one(
+        comodel_name="mail.template",
+        string="Email Template",
+        default=lambda self: self.env.ref(
+            "account_payment_batch_oca.payment_order_mail_notif",
+            raise_if_not_found=False,
+        ),
+        domain="[('model', '=', 'account.payment.order')]",
+        help="Default email template used to notify partners when a payment/debit "
+        "order is marked as uploaded.",
+    )
     mail_partner_policy = fields.Selection(
         [
             ("invoice_partner", "Partner of the Invoice"),

--- a/account_payment_batch_oca/models/account_payment_order.py
+++ b/account_payment_batch_oca/models/account_payment_order.py
@@ -510,9 +510,6 @@ class AccountPaymentOrder(models.Model):
     def generated2uploaded(self):
         self.ensure_one()
         self.payment_ids.action_post()
-        method_line = self.payment_method_line_id
-        mail_notif = method_line.mail_notif
-        partner2mail = {}
         # Perform the reconciliation of payments and source journal items
         # Reminder : in v18, account.payment doesn't always have a move_id
         for payment in self.payment_ids:
@@ -524,72 +521,103 @@ class AccountPaymentOrder(models.Model):
                     if line.account_id.id == payment.destination_account_id.id:
                         lines_to_rec |= line
                 lines_to_rec.reconcile()
-            if mail_notif:
-                if payment.partner_id not in partner2mail:
-                    partner2mail[payment.partner_id] = {
-                        "payments": payment,
-                        "dest_partners": self.env["res.partner"],
-                    }
-                else:
-                    partner2mail[payment.partner_id]["payments"] |= payment
-                for line in payment.payment_line_ids:
-                    if line.mail_notif_partner_id:
-                        partner2mail[payment.partner_id]["dest_partners"] |= (
-                            line.mail_notif_partner_id
-                        )
-        if mail_notif:
-            account_number_scrambled_ctx = {
-                "show_bank_account_chars": method_line.show_bank_account_chars,
-                "show_bank_account": method_line.show_bank_account,
-            }
-            for partner, mail_dict in partner2mail.items():
-                if mail_dict["dest_partners"]:
-                    payments, detail_col = mail_dict[
-                        "payments"
-                    ]._prepare_payment_order_mail(
-                        partner.lang, account_number_scrambled_ctx
-                    )
-                    partner_to = ",".join(
-                        [str(p.id) for p in mail_dict["dest_partners"]]
-                    )
-                    try:
-                        self.env.ref(
-                            "account_payment_batch_oca.payment_order_mail_notif"
-                        ).with_context(
-                            payments=payments,
-                            detail_col=detail_col,
-                            partner_lang=partner.lang,
-                            partner_to=partner_to,
-                            partner_display_name=partner.display_name,
-                            partner_name=partner.name,
-                        ).send_mail(self.id)
-                        logger.info(
-                            "mail generated for partner %s", partner.display_name
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            "Error in the generation of the payment notif mail "
-                            "for partner %s: %s",
-                            partner.display_name,
-                            e,
-                        )
-                        self.message_post(
-                            body=Markup(
-                                self.env._(
-                                    "Odoo <strong>failed to generate the email"
-                                    "</strong> for partner <a href=# "
-                                    "data-oe-model=res.partner "
-                                    "data-oe-id=%(partner_id)d> "
-                                    "%(partner_name)s</a>: %(error)s",
-                                    partner_id=partner.id,
-                                    partner_name=partner.display_name,
-                                    error=e,
-                                )
-                            )
-                        )
+        if self.payment_method_line_id.mail_notif:
+            self._send_generated_uploaded_notifications()
         self.write(
             {"state": "uploaded", "date_uploaded": fields.Date.context_today(self)}
         )
+
+    def _get_generated_uploaded_notification_template(self, mail_template=False):
+        self.ensure_one()
+        if isinstance(mail_template, int):
+            mail_template = self.env["mail.template"].browse(mail_template)
+        return (
+            mail_template[:1]
+            if mail_template
+            else self.payment_method_line_id.order_uploaded_mail_template_id
+        )
+
+    def _get_generated_uploaded_notifications_by_partner(self):
+        self.ensure_one()
+        partner2mail = {}
+        for payment in self.payment_ids:
+            if not payment.partner_id:
+                continue
+            partner_data = partner2mail.setdefault(
+                payment.partner_id.id,
+                {
+                    "partner": payment.partner_id,
+                    "payments": self.env["account.payment"],
+                    "dest_partners": self.env["res.partner"],
+                },
+            )
+            partner_data["payments"] |= payment
+            partner_data["dest_partners"] |= payment.payment_line_ids.mapped(
+                "mail_notif_partner_id"
+            )
+        return partner2mail.values()
+
+    def _send_generated_uploaded_notification(
+        self, partner, payments, dest_partners, mail_template=False
+    ):
+        self.ensure_one()
+        if not dest_partners:
+            return
+        template = self._get_generated_uploaded_notification_template(mail_template)
+        if not template:
+            return
+        account_number_scrambled_ctx = {
+            "show_bank_account_chars": (
+                self.payment_method_line_id.show_bank_account_chars
+            ),
+            "show_bank_account": self.payment_method_line_id.show_bank_account,
+        }
+        payments_vals, detail_col = payments._prepare_payment_order_mail(
+            partner.lang, account_number_scrambled_ctx
+        )
+        partner_to = ",".join([str(partner_id) for partner_id in dest_partners.ids])
+        template.with_context(
+            payments=payments_vals,
+            detail_col=detail_col,
+            partner_lang=partner.lang,
+            partner_to=partner_to,
+            partner_display_name=partner.display_name,
+            partner_name=partner.name,
+        ).send_mail(self.id)
+        logger.info("mail generated for partner %s", partner.display_name)
+
+    def _send_generated_uploaded_notifications(self, mail_template=False):
+        self.ensure_one()
+        for mail_dict in self._get_generated_uploaded_notifications_by_partner():
+            partner = mail_dict["partner"]
+            try:
+                self._send_generated_uploaded_notification(
+                    partner,
+                    mail_dict["payments"],
+                    mail_dict["dest_partners"],
+                    mail_template=mail_template,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Error in the generation of the payment notif mail "
+                    "for partner %s: %s",
+                    partner.display_name,
+                    e,
+                )
+                self.message_post(
+                    body=Markup(
+                        self.env._(
+                            "Odoo <strong>failed to generate the email"
+                            "</strong> for partner <a href=# "
+                            "data-oe-model=res.partner "
+                            "data-oe-id=%(partner_id)d> "
+                            "%(partner_name)s</a>: %(error)s",
+                            partner_id=partner.id,
+                            partner_name=partner.display_name,
+                            error=e,
+                        )
+                    )
+                )
 
     def action_open_payments(self):
         self.ensure_one()

--- a/account_payment_batch_oca/readme/CONTRIBUTORS.md
+++ b/account_payment_batch_oca/readme/CONTRIBUTORS.md
@@ -24,3 +24,4 @@
 - [Open Source Integrators](https://www.opensourceintegrators.com):
   - Ammar Officewala \<<aofficewala@opensourceintegrators.com>\>
 - Marçal Isern \<<marsal.isern@qubiq.es>\>
+- Samir GUESMI \<<samir.guesmi@acsone.eu>\>

--- a/account_payment_batch_oca/static/description/index.html
+++ b/account_payment_batch_oca/static/description/index.html
@@ -460,6 +460,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Marçal Isern &lt;<a class="reference external" href="mailto:marsal.isern&#64;qubiq.es">marsal.isern&#64;qubiq.es</a>&gt;</li>
+<li>Samir GUESMI &lt;<a class="reference external" href="mailto:samir.guesmi&#64;acsone.eu">samir.guesmi&#64;acsone.eu</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/account_payment_batch_oca/tests/test_payment_order_outbound.py
+++ b/account_payment_batch_oca/tests/test_payment_order_outbound.py
@@ -449,3 +449,48 @@ class TestPaymentOrderOutbound(TestPaymentOrderOutboundBase):
         self.assertEqual(len(payment_order.payment_line_ids), 1)
 
         self.assertEqual("F1242 R1234", payment_order.payment_line_ids.communication)
+
+    def test_mail_template_resolution(self):
+        """Check explicit override, method-line default, and cleared default.
+        - new method line defaults to the native OCA template
+        - returns the template configured on the method line when no override is passed
+        - an explicit template (passed by ID) takes over the method-line value
+        - returns False when order_uploaded_mail_template_id is cleared
+        """
+        default_template = self.env.ref(
+            "account_payment_batch_oca.payment_order_mail_notif"
+        )
+        self.assertEqual(self.mode.order_uploaded_mail_template_id, default_template)
+        self.assertEqual(
+            self.env["account.payment.order"]
+            .new({"payment_method_line_id": self.mode.id})
+            ._get_generated_uploaded_notification_template(),
+            default_template,
+        )
+
+        custom_template = self.env["mail.template"].create(
+            {
+                "name": "Custom payment order notification",
+                "model_id": self.env["ir.model"]._get_id("account.payment.order"),
+                "subject": "Custom subject",
+                "body_html": "<p>Custom body</p>",
+            }
+        )
+        self.mode.order_uploaded_mail_template_id = custom_template
+
+        order = self.env["account.payment.order"].new(
+            {
+                "payment_type": "outbound",
+                "payment_method_line_id": self.mode.id,
+            }
+        )
+        self.assertEqual(
+            order._get_generated_uploaded_notification_template(),
+            custom_template,
+        )
+        self.assertEqual(
+            order._get_generated_uploaded_notification_template(default_template.id),
+            default_template,
+        )
+        self.mode.order_uploaded_mail_template_id = False
+        self.assertFalse(order._get_generated_uploaded_notification_template())

--- a/account_payment_batch_oca/views/account_payment_method_line.xml
+++ b/account_payment_batch_oca/views/account_payment_method_line.xml
@@ -45,6 +45,10 @@
                 >
                     <field name="mail_notif" />
                     <field
+                        name="order_uploaded_mail_template_id"
+                        invisible="not mail_notif"
+                    />
+                    <field
                         name="mail_partner_policy"
                         invisible="not mail_notif"
                         widget="radio"


### PR DESCRIPTION
This refactor extracts the email notification logic from generated2uploaded() into dedicated helpers and makes the upload notification template configurable on
  account.payment.method.line.

  Before this change, the notification email was sent directly from generated2uploaded() with a hardcoded template XML ID. That made the flow harder to extend and prevented
  reuse from other features, such as a wizard to resend the notification with another template.