### PR TITLE
[FIX] account_payment_base_oca: avoid displaying the payment method field twice on in_receipt/out_receipt

### DIFF
--- a/account_payment_base_oca/views/account_move.xml
+++ b/account_payment_base_oca/views/account_move.xml
@@ -38,13 +38,13 @@
                     name="preferred_payment_method_line_id"
                     string="Payment Method"
                     domain="[('payment_type', '=', 'inbound'), ('company_id', '=', company_id), ('selectable', '=', True)]"
-                    invisible="move_type in ('in_invoice', 'in_refund')"
+                    invisible="move_type in ('in_invoice', 'in_refund','in_receipt')"
                 />
                 <field
                     name="preferred_payment_method_line_id"
                     string="Payment Method"
                     domain="[('payment_type', '=', 'outbound'), ('company_id', '=', company_id), ('selectable', '=', True)]"
-                    invisible="move_type in ('out_invoice', 'out_refund')"
+                    invisible="move_type in ('out_invoice', 'out_refund','out_receipt')"
                 />
             </field>
         </field>


### PR DESCRIPTION
On purchase receipt, I have the payment method twice: 
<img width="1013" height="292" alt="image" src="https://github.com/user-attachments/assets/2154bee5-369e-4df7-9d73-5134a9309e2c" />

I think that the attribute `invisible` should include `in_receipt` and `out_receipt`